### PR TITLE
feat!: Standardize on kebab-case for cli commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Added
 - Fish completions
 Updated
 - Made adding autocomplete functionality more explicit
+- Base CLI test framework
+- Standardize on kebab-case for cli commands
 Removed
 - References to Phabricator
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1,0 +1,43 @@
+import json
+
+import pytest
+from click.testing import CliRunner
+from transcriptic.cli import cli
+
+
+@pytest.fixture(scope="session")
+def temp_tx_dotfile(tmpdir_factory):
+    path = tmpdir_factory.mktemp("config").join(".transcriptic")
+    config = {
+        "email": "somebody@transcriptic.com",
+        "token": "foobarinvalid",
+        "organization_id": "transcriptic",
+        "api_root": "http://foo:5555",
+        "analytics": True,
+        "user_id": "ufoo2",
+        "feature_groups": [
+            "can_submit_autoprotocol",
+            "can_upload_packages"
+        ]
+    }
+    with open(str(path), "w") as f:
+        json.dump(config, f)
+    return path
+
+
+@pytest.fixture
+def cli_test_runner(temp_tx_dotfile):
+    runner = CliRunner(
+        env={
+            'TRANSCRIPTIC_CONFIG': str(temp_tx_dotfile)
+        }
+    )
+    yield runner
+
+
+def test_kebab_case(cli_test_runner):
+    result = cli_test_runner.invoke(cli, ['--help'])
+    command_str = result.output.split("Commands:\n")[1]
+    commands = [x.strip() for x in command_str.split("\n") if x != '']
+    is_kebab = lambda x: x.islower() and ("_" not in x)
+    assert(all([is_kebab(cmd) for cmd in commands]))

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -276,7 +276,7 @@ def delete_package_cmd(ctx, name, force):
     commands.delete_package(api, name, force)
 
 
-@cli.command('generate_protocol')
+@cli.command('generate-protocol')
 @click.pass_context
 @click.argument('name')
 def generate_protocol_cmd(ctx, name):
@@ -492,7 +492,7 @@ def launch_cmd(ctx, protocol, project, title, save_input, local, accept_quote, p
     commands.launch(api, protocol, project, title, save_input, local, accept_quote, params, pm=None, test=None, pkg=None)
 
 
-@cli.command('select_org')
+@cli.command('select-org')
 @click.argument(
     'organization',
     metavar='ORGANIZATION_NAME',


### PR DESCRIPTION
We currently have a couple of snake_case commands. This standardizes the
commands such that they are consistent.