### PR TITLE
fix: Kinetics Spectrophotomery Plot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 Added
 - Fish completions
+- Autoprotocol dependency for `analysis` package
 Updated
 - Made adding autocomplete functionality more explicit
 - Base CLI test framework
 - Standardize on kebab-case for cli commands
+- Plotly dependency
+Fixed
+- Spectrophotometry.plot() function now works again
 Removed
 - References to Phabricator
 

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,13 @@ jupyter_deps = [
 ]
 
 analysis_deps = [
+    'autoprotocol>=6,<7',
+    'matplotlib>=1.4,<2',
+    'numpy>=1.14,<2',
     'pandas>=0.23,<1',
-    'matplotlib>=1.4, <2',
-    'scipy>=0.14, <1',
-    'numpy>=1.14, <2',
-    'plotly==1.9.6',
-    'pillow>=3, <4'
+    'pillow>=3,<4',
+    'plotly>=1.13,<2',
+    'scipy>=0.14,<1'
 ]
 
 

--- a/transcriptic/jupyter/objects.py
+++ b/transcriptic/jupyter/objects.py
@@ -876,7 +876,7 @@ class Container(_BaseObject):
             from autoprotocol.container_type import _CONTAINER_TYPES
             return _CONTAINER_TYPES[container_type["shortname"]]
         except ImportError:
-            raise warnings.warn("Please install `autoprotocol-python` in order to get container types")
+            warnings.warn("Please install `autoprotocol-python` in order to get container types")
             return None
         except KeyError:
             warnings.warn("ContainerType given is not supported yet in AP-Py")


### PR DESCRIPTION
The current Kinetics.Spectrophotomery.plot function was broken.

Dropping support for older dependencies and updating them seems to be
the easiest solution to fixing this.