### PR TITLE
fix: Spectrophotometry PlateRead plots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,12 @@ Updated
 - Made adding autocomplete functionality more explicit
 - Base CLI test framework
 - Standardize on kebab-case for cli commands
-- Plotly dependency
+- Plotly dependency to 1.13
+- Matplotlib dependency to 3.0.3
+- Spectrophotometry plots now render offline 
 Fixed
-- Spectrophotometry.plot() function now works again
+- Kinetics.Spectrophotometry.plot() function now works again
+- Spectrophotometry.Absorbance/Fluorescence/Luminescence plot() works again
 Removed
 - References to Phabricator
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ jupyter_deps = [
 
 analysis_deps = [
     'autoprotocol>=6,<7',
-    'matplotlib>=1.4,<2',
+    'matplotlib>=3,<4',
     'numpy>=1.14,<2',
     'pandas>=0.23,<1',
     'pillow>=3,<4',

--- a/transcriptic/analysis/spectrophotometry.py
+++ b/transcriptic/analysis/spectrophotometry.py
@@ -2,7 +2,7 @@ from transcriptic.util import humanize
 from transcriptic import dataset as get_dataset
 
 try:
-    import plotly.plotly as py
+    import plotly as py
     import pandas
     import matplotlib.pyplot as plt
     import plotly.tools as tls
@@ -142,6 +142,8 @@ class _PlateRead(object):
         \**plot_kwargs : dict, optional
             Optional dictionary of specifications for your plot type of choice
         """
+        py.offline.init_notebook_mode()
+
         mpl_fig, ax = plt.subplots()
         nl = "\n" if mpl else "<br>"
         ax.set_ylabel(self.op_type + nl + self.params["wavelength"])
@@ -166,7 +168,7 @@ class _PlateRead(object):
                 }
             pyfig = tls.mpl_to_plotly(mpl_fig)
             pyfig.update(plt_kwargs)
-            return py.iplot(pyfig)
+            return py.offline.iplot(pyfig)
 
 
 class Absorbance(_PlateRead):


### PR DESCRIPTION
The current Spectrophotometry.Absorbance, Fluorescence and Luminescence
plots were broken due to regressions in Matplotlib and Plotly.

As an additional fix, offline plots were enabled for Plotly for these
objects to keep them consistent with other plotly plots.