### PR TITLE
build: Bump test dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Added
 - Fish completions
 - Autoprotocol dependency for `analysis` package
 Updated
+- Test dependencies, pytest to 5.4, pylint to 2.5.2, tox to 3.15
 - Travis build reorganized to distinct jobs
 - Support for Python 3.8
 - Made adding autocomplete functionality more explicit

--- a/setup.py
+++ b/setup.py
@@ -32,10 +32,10 @@ test_deps = [
     "jsonschema>=2.6, <3",
     "mock>=3, <4",
     "pre-commit>=2.4, <3",
-    "pylint>=1.9, <2",
-    "pytest>=4, <5",
+    "pylint==2.5.2",  # should be consistent with .pre-commit-config.yaml
+    "pytest>=5.4, <6",
     "pytest-cov>=2, <3",
-    "tox>=3.7, <4",
+    "tox>=3.15, <4",
 ]
 
 doc_deps = [


### PR DESCRIPTION
As we're preparing for a major release, this is an opportunity to
upgrade some of our base dependencies.

This bumps our pytest dependency by one major version. Notably py35
support was dropped, and there has been multiple deprecations which we
are not affected by. There's also a bunch of bugfixes/improvements.

Pylint has been pinned to 2.5.2, which is the same as what we're running
in pre-commit.

Tox has been bumped to 3.15, which brings notable speedups.