### PR TITLE
feat: Support Bearer Token Authentication

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
         args:
         - --disable=W,R,C
         - --rcfile=.pylintrc
+        - --jobs=1
         name: Pylint
         language: system
         types: [python]

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Added
+~~~~~
+
+- Support bearer token authentication
+
 Updated
 ~~~~~~~
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -214,7 +214,7 @@ class ConnectionInitTests(unittest.TestCase):
         prepared_get = connection.session.prepare_request(get_request)
 
         authorization_header_value = prepared_get.headers["authorization"]
-        self.assertEqual(authorization_header_value, bearer_token)
+        self.assertEqual(bearer_token, authorization_header_value)
 
     def test_malformed_bearer_token(self):
         """Verify that an exception is thrown when a malformed JWT bearer token is provided"""

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -174,7 +174,7 @@ class ConnectionInitTests(unittest.TestCase):
     def test_bearer_token(self):
         """Verify that the authorization header is set when a bearer token is provided"""
 
-        bearer_token = "Bearer myBearerToken"
+        bearer_token = "Bearer eyJraWQiOiJWcmVsOE9zZ0JXaUpHeEpMeFJ4bE1UaVwvbjgyc1hwWktUaTd2UExUNFQ0TT0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2IiwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJ3ZWJcL2dldCB3ZWJcL3Bvc3QiLCJhdXRoX3RpbWUiOjE1OTM3MjM1NDgsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xX1d6aEZzTGlPRyIsImV4cCI6MTU5MzcyNzE0OCwiaWF0IjoxNTkzNzIzNTQ4LCJ2ZXJzaW9uIjoyLCJqdGkiOiI4Njk5ZDEwYy05Mjg4LTQ0YmEtODIxNi01OTJjZGU3MDBhY2MiLCJjbGllbnRfaWQiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2In0.YA_yiD-x6UuBMShprUbUKuB_DO6ogCtd5srfgpJA6Ve_qsf8n19nVMmFsZBy3GxzN92P1ZXiFY99FfNPohhQtaRRhpeUkir08hgJN2bEHCJ5Ym8r9mr9mlwSG6FoiedgLaUVGwJujD9c2rcA83NEo8ayTyfCynF2AZ2pMxLHvqOYtvscGMiMzIwlZfJV301iKUVgPODJM5lpJ4iKCpOy2ByCl2_KL1uxIxgMkglpB-i7kgJc-WmYoJFoN88D89ugnEoAxNfK14N4_RyEkrLNGape9kew79nUeR6fWbVFLiGDDu25_9z-7VB-GGGk7L_Hb7YgVJ5W2FwESnkDvV1T4Q"
 
         with tempfile.NamedTemporaryFile() as config_file, tempfile.NamedTemporaryFile() as key_file:
             with open(config_file.name, "w") as f:
@@ -202,3 +202,29 @@ class ConnectionInitTests(unittest.TestCase):
         authorization_header_value = prepared_get.headers["authorization"]
         self.assertEqual(authorization_header_value, bearer_token)
         self.assertNotIn("x-user-token", prepared_get.headers)
+
+    def test_malformed_bearer_token(self):
+        """Verify that an exception is thrown when a malformed JWT bearer token is provided"""
+
+        bearer_token = "Bearer myBigBadBearerToken"
+
+        with tempfile.NamedTemporaryFile() as config_file, tempfile.NamedTemporaryFile() as key_file:
+            with open(config_file.name, "w") as f:
+                json.dump(
+                    {
+                        "email": "somebody@transcriptic.com",
+                        "token": bearer_token,
+                        "organization_id": "transcriptic",
+                        "api_root": "http://foo:5555",
+                        "analytics": True,
+                        "user_id": "ufoo2",
+                        "feature_groups": [
+                            "can_submit_autoprotocol",
+                            "can_upload_packages",
+                        ],
+                    },
+                    f,
+                )
+
+            with self.assertRaisesRegexp(ValueError, "Malformed JWT Bearer Token"):
+                transcriptic.config.Connection.from_file(config_file.name)

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -174,14 +174,28 @@ class ConnectionInitTests(unittest.TestCase):
     def test_bearer_token(self):
         """Verify that the authorization header is set when a bearer token is provided"""
 
-        bearer_token = "Bearer eyJraWQiOiJWcmVsOE9zZ0JXaUpHeEpMeFJ4bE1UaVwvbjgyc1hwWktUaTd2UExUNFQ0TT0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2IiwidG9rZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJ3ZWJcL2dldCB3ZWJcL3Bvc3QiLCJhdXRoX3RpbWUiOjE1OTM3MjM1NDgsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9uYXdzLmNvbVwvdXMtZWFzdC0xX1d6aEZzTGlPRyIsImV4cCI6MTU5MzcyNzE0OCwiaWF0IjoxNTkzNzIzNTQ4LCJ2ZXJzaW9uIjoyLCJqdGkiOiI4Njk5ZDEwYy05Mjg4LTQ0YmEtODIxNi01OTJjZGU3MDBhY2MiLCJjbGllbnRfaWQiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2In0.YA_yiD-x6UuBMShprUbUKuB_DO6ogCtd5srfgpJA6Ve_qsf8n19nVMmFsZBy3GxzN92P1ZXiFY99FfNPohhQtaRRhpeUkir08hgJN2bEHCJ5Ym8r9mr9mlwSG6FoiedgLaUVGwJujD9c2rcA83NEo8ayTyfCynF2AZ2pMxLHvqOYtvscGMiMzIwlZfJV301iKUVgPODJM5lpJ4iKCpOy2ByCl2_KL1uxIxgMkglpB-i7kgJc-WmYoJFoN88D89ugnEoAxNfK14N4_RyEkrLNGape9kew79nUeR6fWbVFLiGDDu25_9z-7VB-GGGk7L_Hb7YgVJ5W2FwESnkDvV1T4Q"
+        bearer_token = (
+            "Bearer eyJraWQiOiJWcmVsOE9zZ0JXaUpHeEpMeFJ4bE1UaVwvbjgyc1hwWktUaTd2UExUNFQ0T"
+            "T0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2IiwidG9r"
+            "ZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJ3ZWJcL2dldCB3ZWJcL3Bvc3QiLCJhdXRoX3RpbWUi"
+            "OjE1OTM3MjM1NDgsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9u"
+            "YXdzLmNvbVwvdXMtZWFzdC0xX1d6aEZzTGlPRyIsImV4cCI6MTU5MzcyNzE0OCwiaWF0IjoxNTkz"
+            "NzIzNTQ4LCJ2ZXJzaW9uIjoyLCJqdGkiOiI4Njk5ZDEwYy05Mjg4LTQ0YmEtODIxNi01OTJjZGU3"
+            "MDBhY2MiLCJjbGllbnRfaWQiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2In0.YA_yiD-x6UuB"
+            "MShprUbUKuB_DO6ogCtd5srfgpJA6Ve_qsf8n19nVMmFsZBy3GxzN92P1ZXiFY99FfNPohhQtaRR"
+            "hpeUkir08hgJN2bEHCJ5Ym8r9mr9mlwSG6FoiedgLaUVGwJujD9c2rcA83NEo8ayTyfCynF2AZ2p"
+            "MxLHvqOYtvscGMiMzIwlZfJV301iKUVgPODJM5lpJ4iKCpOy2ByCl2_KL1uxIxgMkglpB-i7kgJc"
+            "-WmYoJFoN88D89ugnEoAxNfK14N4_RyEkrLNGape9kew79nUeR6fWbVFLiGDDu25_9z-7VB-GGGk"
+            "7L_Hb7YgVJ5W2FwESnkDvV1T4Q"
+        )
 
         with tempfile.NamedTemporaryFile() as config_file, tempfile.NamedTemporaryFile() as key_file:
             with open(config_file.name, "w") as f:
                 json.dump(
                     {
                         "email": "somebody@transcriptic.com",
-                        "token": bearer_token,
+                        "token": "foobarinvalid",
+                        "bearer_token": bearer_token,
                         "organization_id": "transcriptic",
                         "api_root": "http://foo:5555",
                         "analytics": True,
@@ -201,7 +215,6 @@ class ConnectionInitTests(unittest.TestCase):
 
         authorization_header_value = prepared_get.headers["authorization"]
         self.assertEqual(authorization_header_value, bearer_token)
-        self.assertNotIn("x-user-token", prepared_get.headers)
 
     def test_malformed_bearer_token(self):
         """Verify that an exception is thrown when a malformed JWT bearer token is provided"""
@@ -213,7 +226,8 @@ class ConnectionInitTests(unittest.TestCase):
                 json.dump(
                     {
                         "email": "somebody@transcriptic.com",
-                        "token": bearer_token,
+                        "token": "foobarinvalid",
+                        "bearer_token": bearer_token,
                         "organization_id": "transcriptic",
                         "api_root": "http://foo:5555",
                         "analytics": True,

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -3,6 +3,7 @@ import unittest
 import tempfile
 import re
 
+import pytest
 import requests
 from email.utils import formatdate
 
@@ -208,7 +209,7 @@ class ConnectionInitTests(unittest.TestCase):
 
         bearer_token = "Bearer myBigBadBearerToken"
 
-        with self.assertRaisesRegexp(ValueError, "Malformed JWT Bearer Token"):
+        with pytest.raises(ValueError, match="Malformed JWT Bearer Token"):
             transcriptic.Connection(
                 email="somebody@transcriptic.com",
                 bearer_token=bearer_token,

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -196,10 +196,7 @@ class ConnectionInitTests(unittest.TestCase):
 
             connection = transcriptic.config.Connection.from_file(config_file.name)
 
-        get_request = requests.Request(
-            "GET",
-            "http://foo:5555/get"
-        )
+        get_request = requests.Request("GET", "http://foo:5555/get")
         prepared_get = connection.session.prepare_request(get_request)
 
         authorization_header_value = prepared_get.headers["authorization"]

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -251,11 +251,12 @@ class Connection(object):
             )
             self.update_headers(**{"Cookie": None})
 
-        is_bearer_token = value.startswith("Bearer")
-        if is_bearer_token:
-            self.update_headers(**{"Authorization": value})
-        else:
-            self.update_headers(**{"X-User-Token": value})
+        if value is not None:
+            is_bearer_token = value.startswith("Bearer")
+            if is_bearer_token:
+                self.update_headers(**{"Authorization": value})
+            else:
+                self.update_headers(**{"X-User-Token": value})
 
     @property
     def cookie(self):

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -12,6 +12,7 @@ import zipfile
 
 from . import routes
 from .signing import StrateosSign
+from .util import is_valid_jwt_token
 from .version import __version__
 
 try:
@@ -252,9 +253,12 @@ class Connection(object):
             self.update_headers(**{"Cookie": None})
 
         if value is not None:
-            is_bearer_token = value.startswith("Bearer")
-            if is_bearer_token:
-                self.update_headers(**{"Authorization": value})
+            is_bearer_auth = value.startswith("Bearer")
+            if is_bearer_auth:
+                if is_valid_jwt_token(value):
+                    self.update_headers(**{"Authorization": value})
+                else:
+                    raise ValueError("Malformed JWT Bearer Token")
             else:
                 self.update_headers(**{"X-User-Token": value})
 

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -1106,9 +1106,11 @@ class Connection(object):
                 input_args.append(arg_dict[arg])
             else:
                 raise Exception(
-                    f"For route: {method}, argument {arg} needs " f"to be provided."
+                    f"For route: {method}, argument {arg} needs to be provided."
                 )
-        return route_method(*tuple(input_args))
+        return route_method(  # pylint: disable=no-value-for-parameter
+            *tuple(input_args)
+        )
 
     def get(self, route, **kwargs):
         return self._call("get", route, **kwargs)

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -155,7 +155,12 @@ class Connection(object):
             self.email = email
             if token is not None:
                 self.token = token
-            if bearer_token is not None:
+                if bearer_token is not None:
+                    warnings.warn(
+                        "User token and bearer token authentication"
+                        "is mutually exclusive. Ignoring bearer token"
+                    )
+            elif bearer_token is not None:
                 self.bearer_token = bearer_token
             self.update_session_auth()
 

--- a/transcriptic/signing.py
+++ b/transcriptic/signing.py
@@ -46,3 +46,12 @@ class StrateosSign(AuthBase):
             return self.body_auth(request)
 
         return self.auth(request)
+
+
+class BearerAuth(AuthBase):
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r):
+        r.headers["authorization"] = self.token
+        return r

--- a/transcriptic/util.py
+++ b/transcriptic/util.py
@@ -92,3 +92,8 @@ def makedirs(name, mode=None, exist_ok=False):
 
     mode = mode if mode is not None else 0o777
     makedirs(name, mode, exist_ok)
+
+
+def is_valid_jwt_token(token: str):
+    regex = r"Bearer ([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_=]+)\.([a-zA-Z0-9_\-\+\/=]*)"
+    return re.fullmatch(regex, token) is not None


### PR DESCRIPTION
We will soon be passing a client_credentials (service-to-service) bearer token to programs when executing in the context of Igor. Web will validate the bearer token (and only the bearer token, no user token needed) when receiving an API request.

Programs internally call the transcriptic library (this repo) to form an API `Connection`.

The change in this PR involves changing the Connection instantiation routine to recognize if the token is a `Bearer` token and, if so, set the standard OAuth `Authorization` header (and no `X-User-Token` header). This is opposed to a non-bearer token, which will result in the usual `X-User-Token` header.

Jira Issue: SEA-271