### PR TITLE
Request Signing and Bearer Token Auth Issues: PP-2306 and PP-2307

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,13 @@ Added
 
 - Codecov configuration for coverage
 
+v8.1.1
+------
+Fixed
+~~~~~
+
+- Encoding error when using dataset upload API with request signing enabled
+- Bad request error when making calls to non-Strateos endpoints (e.g. S3) with authorization headers set
 
 v8.1.0
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,8 +9,6 @@ Added
 
 - Codecov configuration for coverage
 
-v8.1.1
-------
 Fixed
 ~~~~~
 

--- a/transcriptic/auth.py
+++ b/transcriptic/auth.py
@@ -9,7 +9,6 @@ from urllib.parse import urlparse
 
 
 class StrateosAuthBase(AuthBase, ABC):
-
     def __init__(self, api_root):
         self.api_root = api_root
 

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -14,7 +14,7 @@ from jinja2 import Environment, PackageLoader
 from os.path import isfile, expanduser, abspath
 from transcriptic.english import AutoprotocolParser
 from transcriptic.config import Connection
-from transcriptic.signing import StrateosSign
+from transcriptic.auth import StrateosSign
 from transcriptic.util import iter_json, flatmap, ascii_encode, makedirs
 from transcriptic import routes
 
@@ -1022,7 +1022,7 @@ def login(api, config, api_root=None, analytics=True, rsa_key=None):
         # Try making an auth handler with a dummy email so that the command
         # fails early
         try:
-            rsa_auth = StrateosSign("foo@bar.com", rsa_secret)
+            rsa_auth = StrateosSign("foo@bar.com", rsa_secret, api_root)
         except Exception as e:
             click.echo(f"Error loading RSA key: {e}")
             sys.exit(1)
@@ -1032,7 +1032,7 @@ def login(api, config, api_root=None, analytics=True, rsa_key=None):
 
     # replace the dummy rsa_auth with a handler using the given email
     if rsa_auth is not None:
-        rsa_auth = StrateosSign(email, rsa_auth.secret)
+        rsa_auth = StrateosSign(email, rsa_auth.secret, api_root)
 
     try:
         r = api.post(

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1037,8 +1037,18 @@ def login(api, config, api_root=None, analytics=True, rsa_key=None):
     try:
         r = api.post(
             routes.login(api_root=api_root),
-            data=json.dumps({"user": {"email": email, "password": password,},}),
-            headers={"Accept": "application/json", "Content-Type": "application/json",},
+            data=json.dumps(
+                {
+                    "user": {
+                        "email": email,
+                        "password": password,
+                    },
+                }
+            ),
+            headers={
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
             status_response={
                 "200": lambda resp: resp,
                 "401": lambda resp: resp,

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1037,18 +1037,8 @@ def login(api, config, api_root=None, analytics=True, rsa_key=None):
     try:
         r = api.post(
             routes.login(api_root=api_root),
-            data=json.dumps(
-                {
-                    "user": {
-                        "email": email,
-                        "password": password,
-                    },
-                }
-            ),
-            headers={
-                "Accept": "application/json",
-                "Content-Type": "application/json",
-            },
+            data=json.dumps({"user": {"email": email, "password": password,},}),
+            headers={"Accept": "application/json", "Content-Type": "application/json",},
             status_response={
                 "200": lambda resp: resp,
                 "401": lambda resp: resp,

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -11,7 +11,7 @@ import warnings
 import zipfile
 
 from . import routes
-from .auth import StrateosSign, BearerAuth
+from .auth import StrateosSign, StrateosBearerAuth
 from .util import is_valid_jwt_token
 from .version import __version__
 
@@ -357,7 +357,7 @@ class Connection(object):
                 self.email, self._rsa_secret, self.api_root
             )
         elif self.bearer_token:
-            self.session.auth = BearerAuth(self.bearer_token, self.api_root)
+            self.session.auth = StrateosBearerAuth(self.bearer_token, self.api_root)
         else:
             self.session.auth = None
 

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -353,9 +353,11 @@ class Connection(object):
             and self._rsa_secret
             and "X-User-Email" in self.session.headers
         ):
-            self.session.auth = StrateosSign(self.email, self._rsa_secret)
+            self.session.auth = StrateosSign(
+                self.email, self._rsa_secret, self.api_root
+            )
         elif self.bearer_token:
-            self.session.auth = BearerAuth(self.bearer_token)
+            self.session.auth = BearerAuth(self.bearer_token, self.api_root)
         else:
             self.session.auth = None
 

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -11,7 +11,7 @@ import warnings
 import zipfile
 
 from . import routes
-from .signing import StrateosSign, BearerAuth
+from .auth import StrateosSign, BearerAuth
 from .util import is_valid_jwt_token
 from .version import __version__
 


### PR DESCRIPTION
See Jira issues for detailed description.

In a nutshell:

1. When bearer token auth or request signing is used, we set an authorization header for _all_ outgoing requests. This is problematic as we not only make requests to our own web endpoints, but also to S3, where it clashes with their query param auth scheme. The fix is to pass the `api_root` (e.g. https://secure.transcriptic.com) to the Signing initialization routine and only set the auth headers on outgoing requests that are destined for endpoints under our api_root.

2. When request signing is enabled, we encode the request body as part of determining the digest. It looks like for some calls (e.g. the POST with the data upload reference), the request body is already encoded (as `bytes`). So when we try to encode something that is already encoded, an exception is thrown. The fix is to check the type prior to encoding - only encode if needed. Note, during dataset upload, the actual binary being uploaded is never encoded, as that call is destined for S3 (a non-api_root endpoint), so #1 takes care to skip this routine altogether.

Some more info on #2, it looks like the request body is `bytes` when `json` is passed as an argument instead of `data` when making a `Request`. There are instances of each in our API calls.
```
    :param data: the body to attach to the request. If a dictionary or
        list of tuples ``[(key, value)]`` is provided, form-encoding will
        take place.
    :param json: json for the body to attach to the request (if files or data is not specified).
```