### PR TITLE
feat: Remove unused scipy dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Updated
+~~~~~~~
+
+- Remove unused `scipy` dependency
+
+
 v8.1.2
 ------
 
@@ -24,6 +33,7 @@ Fixed
 - Repeated deploy issue with Travis config
 - Encoding error when using dataset upload API with request signing enabled
 - Bad request error when making calls to non-Strateos endpoints (e.g. S3) with authorization headers set
+
 
 v8.1.0
 ------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,6 @@ class Mock(MagicMock):
 # MOCK_MODULES list below)
 MOCK_MODULES = [
     "numpy",
-    "scipy",
     "matplotlib",
     "matplotlib.pyplot",
     "sklearn.grid_search",

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ analysis_deps = [
     "pandas>=0.23,<1",
     "pillow>=3,<4",
     "plotly>=1.13,<2",
-    "scipy>=0.14,<1",
 ]
 
 


### PR DESCRIPTION
We have a scipy dependency which is currently unused. The current
version bounds is causing downstream build errors for Py 37/38.