### PR TITLE
build: Fix Travis bash syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ deploy:
     repo: strateos/transcriptic
     tags: true
     python: '3.6'
-    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ AND env(DEPLOY) = true'
+    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && $DEPLOY = true'
 - provider: pypi
   skip_cleanup: true
   username: '__token__'
@@ -47,4 +47,4 @@ deploy:
   on:
     tags: true
     python: '3.6'
-    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ AND env(DEPLOY) = true'
+    condition: '$TRAVIS_TAG =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && $DEPLOY = true'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+Fixed
+~~~~~
+
+- Issue with bash syntax for Travis config
+
+
 v8.1.1
 ------
 


### PR DESCRIPTION
Travis uses bash syntax for conditionals instead of its usual expressions syntax. See https://docs.travis-ci.com/user/deployment#conditional-releases-with-on

Tested this on a test repository.