### PR TITLE
refactor: Use isort for import sorting

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+profile = black
+atomic = true
+include_trailing_comma = true
+lines_after_imports = 2
+lines_between_types = 1
+use_parentheses = true
+src_paths = ["transcriptic", "test"]
+filter_files = true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
     hooks:
     -   id: black
         language_version: python3.6
+-   repo: https://github.com/timothycrosley/isort
+    rev: 5.6.4
+    hooks:
+    - id: isort
 -   repo: https://github.com/pycqa/pylint
     rev: pylint-2.5.2
     hooks:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,14 @@ Changelog
 Unreleased
 ----------
 
+Added
+~~~~~
+
+- isort for automatic import sorting
+
 Fixed
 ~~~~~
+
 - Issue with CodeCov for GitHub action CI
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
+import sys
+
 from mock import Mock as MagicMock
 
 

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import sys
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
+
 # Load version
 exec(open("transcriptic/version.py").read())
 

--- a/test/AP2En_test.py
+++ b/test/AP2En_test.py
@@ -1,6 +1,8 @@
-import pytest
-import unittest
 import json
+import unittest
+
+import pytest
+
 from transcriptic import english
 
 

--- a/test/analysis/kinetics_test.py
+++ b/test/analysis/kinetics_test.py
@@ -1,8 +1,8 @@
 import pytest
-from pandas import DatetimeTZDtype
 
-from transcriptic.sampledata.connection import MockConnection
+from pandas import DatetimeTZDtype
 from transcriptic.analysis.kinetics import *
+from transcriptic.sampledata.connection import MockConnection
 from transcriptic.sampledata.dataset import load_sample_kinetics_datasets
 
 

--- a/test/analysis/spectrophotometry_test.py
+++ b/test/analysis/spectrophotometry_test.py
@@ -3,9 +3,9 @@ from contextlib import contextmanager
 import pandas as pd
 import pytest
 
+from transcriptic.analysis.spectrophotometry import *
 from transcriptic.sampledata.connection import MockConnection
 from transcriptic.sampledata.dataset import load_sample_absorbance_dataset
-from transcriptic.analysis.spectrophotometry import *
 
 
 @contextmanager

--- a/test/api_test.py
+++ b/test/api_test.py
@@ -1,5 +1,7 @@
 import pytest
+
 from transcriptic.config import AnalysisException
+
 from .helpers.mockAPI import mockRoute
 
 

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -1,8 +1,9 @@
 import json
 
 import pytest
-from Crypto.PublicKey import RSA
+
 from click.testing import CliRunner
+from Crypto.PublicKey import RSA
 from transcriptic.cli import cli
 
 

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,13 +1,14 @@
 import json
-import unittest
-import tempfile
 import re
+import tempfile
+import unittest
+
+from email.utils import formatdate
 
 import pytest
 import requests
-from email.utils import formatdate
-
 import transcriptic.config
+
 
 try:
     from unittest.mock import Mock

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,11 @@
-import pytest
-
 import os
 import sys
+
+import pytest
+
 from .helpers.mockAPI import MockResponse
 from .helpers.util import load_protocol
+
 
 sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 
@@ -11,6 +13,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), "helpers"))
 @pytest.fixture()
 def test_api(monkeypatch):
     from transcriptic.config import Connection
+
     from .helpers.mockAPI import _req_call as mockCall
 
     api = Connection(email="mock@api.com", organization_id="mock", api_root="mock-api")

--- a/test/helpers/mockAPI.py
+++ b/test/helpers/mockAPI.py
@@ -1,6 +1,7 @@
 from builtins import object
 from collections import deque
 
+
 """Keys in mockDB correspond to (method, route) calls"""
 mockDB = dict()
 

--- a/test/helpers/protocol_response.py
+++ b/test/helpers/protocol_response.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
+
 import json
 import os
+
 import requests
 
 

--- a/test/sampledata/connection_test.py
+++ b/test/sampledata/connection_test.py
@@ -6,12 +6,12 @@ from transcriptic.sampledata import load_sample_container
 from transcriptic.sampledata.connection import MockConnection
 from transcriptic.sampledata.container import sample_container_attr
 from transcriptic.sampledata.dataset import (
-    sample_dataset_attr,
-    load_sample_dataset,
     ABSORBANCE_DATASETS,
+    load_sample_dataset,
+    sample_dataset_attr,
 )
-from transcriptic.sampledata.project import sample_project_attr, load_sample_project
-from transcriptic.sampledata.run import sample_run_attr, load_sample_run
+from transcriptic.sampledata.project import load_sample_project, sample_project_attr
+from transcriptic.sampledata.run import load_sample_run, sample_run_attr
 from transcriptic.util import load_sampledata_json
 
 

--- a/transcriptic/__init__.py
+++ b/transcriptic/__init__.py
@@ -1,6 +1,7 @@
 from .config import Connection
 from .version import __version__
 
+
 api = None
 
 """
@@ -24,8 +25,8 @@ to the Jupyter library.
 required imports are present
 """
 try:
-    from .jupyter import Run, Project, Container, Dataset
     from .commands import ProtocolPreview
+    from .jupyter import Container, Dataset, Project, Run
 except ImportError as e:
     pass
 

--- a/transcriptic/analysis/imaging.py
+++ b/transcriptic/analysis/imaging.py
@@ -2,6 +2,7 @@ from io import BytesIO
 
 from transcriptic import api
 
+
 try:
     from PIL import Image
 except ImportError:

--- a/transcriptic/analysis/kinetics.py
+++ b/transcriptic/analysis/kinetics.py
@@ -1,7 +1,7 @@
 try:
+    import pandas as pd
     import plotly as py
     import plotly.graph_objs as go
-    import pandas as pd
 except ImportError:
     raise ImportError(
         "Please run `pip install transcriptic[analysis] if you "

--- a/transcriptic/analysis/spectrophotometry.py
+++ b/transcriptic/analysis/spectrophotometry.py
@@ -1,12 +1,13 @@
 from autoprotocol.container_type import ContainerType
 from transcriptic import dataset as get_dataset
 
+
 try:
-    import plotly as py
-    import pandas
     import matplotlib.pyplot as plt
-    import plotly.tools as tls
     import numpy as np
+    import pandas
+    import plotly as py
+    import plotly.tools as tls
 except ImportError:
     raise ImportError(
         "Please run `pip install transcriptic[analysis] if you "

--- a/transcriptic/auth.py
+++ b/transcriptic/auth.py
@@ -1,11 +1,13 @@
 import base64
+
 from abc import ABC
 from email.utils import formatdate
+from urllib.parse import urlparse
+
 from Crypto.Hash import SHA256
+from httpsig.requests_auth import HTTPSignatureAuth
 from httpsig.utils import HttpSigException
 from requests.auth import AuthBase
-from httpsig.requests_auth import HTTPSignatureAuth
-from urllib.parse import urlparse
 
 
 class StrateosAuthBase(AuthBase, ABC):

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
-import click
 import os
+
+import click
 import requests
 
-from transcriptic.config import Connection
 from transcriptic import commands
+from transcriptic.config import Connection
 
 
 class FeatureGroup(click.Group):

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1,24 +1,25 @@
 #!/usr/bin/env python3
 
-import click
 import json
 import locale
 import os
+import sys
 import time
 import zipfile
-import requests
 
 from collections import OrderedDict
 from contextlib import contextmanager
-from jinja2 import Environment, PackageLoader
-from os.path import isfile, expanduser, abspath
-from transcriptic.english import AutoprotocolParser
-from transcriptic.config import Connection
-from transcriptic.auth import StrateosSign
-from transcriptic.util import iter_json, flatmap, ascii_encode, makedirs
-from transcriptic import routes
+from os.path import abspath, expanduser, isfile
 
-import sys
+import click
+import requests
+
+from jinja2 import Environment, PackageLoader
+from transcriptic import routes
+from transcriptic.auth import StrateosSign
+from transcriptic.config import Connection
+from transcriptic.english import AutoprotocolParser
+from transcriptic.util import ascii_encode, flatmap, iter_json, makedirs
 
 
 def submit(api, file, project, title=None, test=None, pm=None):
@@ -919,7 +920,7 @@ def launch(
         if not project:
             return
 
-        from time import strftime, gmtime
+        from time import gmtime, strftime
 
         if title:
             default_title = f"{title}_{strftime('%b_%d_%Y', gmtime())}"
@@ -1398,8 +1399,9 @@ def run_protocol(api, manifest, protocol, inputs, view=False, dye_test=False):
         )
         return
 
-    from subprocess import check_output, CalledProcessError
     import tempfile
+
+    from subprocess import CalledProcessError, check_output
 
     with tempfile.NamedTemporaryFile() as fp:
         fp.write(bytes(json.dumps(inputs), "UTF-8"))

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -3,17 +3,20 @@ import io
 import json
 import os
 import platform
-import requests
 import time
-from Crypto.PublicKey import RSA
-import transcriptic
 import warnings
 import zipfile
 
+import requests
+import transcriptic
+
+from Crypto.PublicKey import RSA
+
 from . import routes
-from .auth import StrateosSign, StrateosBearerAuth
+from .auth import StrateosBearerAuth, StrateosSign
 from .util import is_valid_jwt_token
 from .version import __version__
+
 
 try:
     import magic

--- a/transcriptic/english.py
+++ b/transcriptic/english.py
@@ -1,6 +1,7 @@
-import json
 import ast
+import json
 import re
+
 from collections import OrderedDict
 
 

--- a/transcriptic/jupyter/container.py
+++ b/transcriptic/jupyter/container.py
@@ -1,4 +1,5 @@
 import warnings
+
 from operator import itemgetter
 
 import pandas as pd

--- a/transcriptic/jupyter/dataobject.py
+++ b/transcriptic/jupyter/dataobject.py
@@ -1,4 +1,5 @@
 import json
+
 from io import StringIO
 
 import pandas as pd

--- a/transcriptic/jupyter/dataset.py
+++ b/transcriptic/jupyter/dataset.py
@@ -1,4 +1,5 @@
 import warnings
+
 from copy import deepcopy
 
 import pandas as pd

--- a/transcriptic/jupyter/run.py
+++ b/transcriptic/jupyter/run.py
@@ -1,4 +1,5 @@
 import pandas as pd
+
 from requests.exceptions import ReadTimeout
 
 from .common import _BaseObject

--- a/transcriptic/sampledata/__init__.py
+++ b/transcriptic/sampledata/__init__.py
@@ -1,3 +1,3 @@
+from .container import load_sample_container
 from .project import load_sample_project
 from .run import load_sample_run
-from .container import load_sample_container

--- a/transcriptic/sampledata/connection.py
+++ b/transcriptic/sampledata/connection.py
@@ -1,8 +1,7 @@
-from transcriptic.config import Connection
-from requests.exceptions import ConnectionError
-
 import responses
 
+from requests.exceptions import ConnectionError
+from transcriptic.config import Connection
 from transcriptic.sampledata.project import sample_project_attr
 from transcriptic.sampledata.run import sample_run_attr
 from transcriptic.util import load_sampledata_json

--- a/transcriptic/util.py
+++ b/transcriptic/util.py
@@ -1,9 +1,10 @@
-from os.path import join, abspath, dirname
+import itertools
+import json
+import re
+
+from os.path import abspath, dirname, join
 
 import click
-import itertools
-import re
-import json
 
 
 def natural_sort(l):


### PR DESCRIPTION
Add isort for consistent, automatic import sorting. Generally, the order
is system imports, library imports, direct (from) imports and
alphabetical.

Refer to https://github.com/PyCQA/isort for more configuration
information.