### PR TITLE
feat: Support Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Added
 ~~~~~
 
 - isort for automatic import sorting
+- Python 3.9 support. Added to test suite.
 
 Fixed
 ~~~~~

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = clean, py36, py37, py38, stats, lint, docs
+envlist = clean, py36, py37, py38, py39, stats, lint, docs
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
There are no obvious regressions for Python 3.9. Checking this into our
test suite so that we can be notified of any future regressions.