### PR TITLE
test: Plumb posargs through for tox

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,11 +14,6 @@ Added
 - Deprecation warning for existing `-i` option for `projects` command.
 - Binder build cache step
 
-Updated
-~~~~~~~
-
-- Remove notebooks directory as we break it out into a `separate repository <https://github.com/open-strateos/txpy_jupyter_notebooks>`_
-
 Fixed
 ~~~~~
 
@@ -33,6 +28,8 @@ Updated
 - Added new option "--names" to `projects` CLI command. This is meant as a better
   named and more intuitive replacement for the existing `-i` option.
 - Returned more explicit error statuses for `projects` and `submit` commands.
+- Remove notebooks directory as we break it out into a `separate repository <https://github.com/open-strateos/txpy_jupyter_notebooks>`_
+- Plumbed test posargs through to allow local execution of specific test files.
 
 v9.0.0
 ------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -92,7 +92,7 @@ the root folder.
 
 If you’re using `pyenv <https://github.com/pyenv/pyenv>`__ to manage
 python versions, ensure you have all the tested environments in your
-``.python-version`` file. i.e.\ ``pyenv local 3.6.12 3.7.9 3.8.7 ``
+``.python-version`` file. i.e.\ ``pyenv local 3.6.12 3.7.9 3.8.7``
 
 Running Specific Tests
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -78,7 +78,7 @@ For testing purposes, we write tests in the ``test`` folder in the
 also use `tox <https://tox.readthedocs.org/en/latest/>`__ for automating
 tests.
 
-The ``tox`` command is run by Jenkins and is currently configured to run
+The ``tox`` command is run by CI and is currently configured to run
 the main module tests, generate a coverage report and build
 documentation.
 
@@ -92,7 +92,7 @@ the root folder.
 
 If you’re using `pyenv <https://github.com/pyenv/pyenv>`__ to manage
 python versions, ensure you have all the tested environments in your
-``.python-version`` file. i.e.\ ``pyenv local 3.5.6 3.6.8 3.7.3``
+``.python-version`` file. i.e.\ ``pyenv local 3.6.12 3.7.9 3.8.7 ``
 
 Running Specific Tests
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -102,6 +102,9 @@ Specific tests are controlled by the ``tox.ini`` configuration file.
 To run just the main module tests, execute ``python setup.py test`` in
 the root folder. This is specified by the main ``[testenv]`` flag in
 ``tox.ini``.
+
+To run a specific test, execute ``python setup.py test -a path/to/test.py``.
+Using tox, ``tox -e py36 -- -a path/to/test.py``.
 
 To build the docs locally, execute
 ``sphinx-build -W -b html -d tmp/doctrees . -d tmp/html`` in the

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = clean, py36, py37, py38, stats, lint, docs
 
 [testenv]
-commands = python setup.py test
+commands = python setup.py test {posargs}
 deps = .[test, jupyter, analysis]
 
 [testenv:clean]


### PR DESCRIPTION
Plumbing posargs through would allow devs to run specific tests locally
using a tox environment.

Updated the documentation to reflect that pattern.