### PR TITLE
feat: Make api option required for exec

### DIFF
--- a/test/commands/exec_test.py
+++ b/test/commands/exec_test.py
@@ -26,6 +26,12 @@ def ap_file(tmpdir_factory):
     return path
 
 
+def test_unspecified_api(cli_test_runner, ap_file):
+    result = cli_test_runner.invoke(cli, ["exec", str(ap_file)])
+    assert result.exit_code != 0
+    assert "Missing option '--api'" in result.stderr
+
+
 def test_good_autoprotocol(cli_test_runner, monkeypatch, ap_file):
     def mockpost(*args, **kwargs):
         return MockResponse(0, bool_success_res(), json.dumps(bool_success_res()))

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -633,7 +633,10 @@ def format_cmd(manifest):
 @cli.command("exec")
 @click.argument("autoprotocol", type=click.File("r"), default=sys.stdin)
 @click.option(
-    "--api", "-a", help="The api endpoint of your scle test workcell instance."
+    "--api",
+    "-a",
+    help="The api endpoint of your scle test workcell instance.",
+    required=True,
 )
 @click.option(
     "--workcell-id",


### PR DESCRIPTION
When testing `transcriptic exec`, noticed that we are implicitly
requiring `api` option to be specified.

Not specifying `api` currently results in a non-helpful error message,
so this makes it explicitly required.