### PR TITLE
feature: handle new frontend deployment for frontend

### DIFF
--- a/test/commands/exec_test.py
+++ b/test/commands/exec_test.py
@@ -115,6 +115,7 @@ def test_good_workcell(cli_test_runner, monkeypatch, ap_file):
         in result.output
     )
 
+
 def test_session_id(cli_test_runner, monkeypatch, ap_file):
     sessionId = "hi_there"
 

--- a/test/commands/exec_test.py
+++ b/test/commands/exec_test.py
@@ -116,6 +116,14 @@ def test_good_workcell(cli_test_runner, monkeypatch, ap_file):
     )
 
 
+def test_bad_workcell(cli_test_runner, monkeypatch, ap_file):
+    result = cli_test_runner.invoke(
+        cli, ["exec", str(ap_file), "-a", mock_api_endpoint(), "-w", "hello.world"]
+    )
+    assert result.exit_code != 0
+    assert "Error: " in result.stderr
+
+
 def test_session_id(cli_test_runner, monkeypatch, ap_file):
     sessionId = "hi_there"
 

--- a/test/commands/exec_test.py
+++ b/test/commands/exec_test.py
@@ -14,7 +14,7 @@ def queue_test_success_res(sessionId="testSessionId"):
 
 
 def mock_api_endpoint():
-    return "foo.bar.baz"
+    return "foo.bar.baz/lab/workcell"
 
 
 @pytest.fixture

--- a/test/commands/exec_test.py
+++ b/test/commands/exec_test.py
@@ -115,15 +115,6 @@ def test_good_workcell(cli_test_runner, monkeypatch, ap_file):
         in result.output
     )
 
-
-def test_bad_workcell(cli_test_runner, ap_file):
-    result = cli_test_runner.invoke(
-        cli, ["exec", str(ap_file), "-a", mock_api_endpoint(), "-w", "bad-workcell-id"]
-    )
-    assert result.exit_code != 0
-    assert "Workcell id must be like wcN but was bad-workcell-id" in result.stderr
-
-
 def test_session_id(cli_test_runner, monkeypatch, ap_file):
     sessionId = "hi_there"
 

--- a/test/commands/exec_test.py
+++ b/test/commands/exec_test.py
@@ -13,8 +13,16 @@ def queue_test_success_res(sessionId="testSessionId"):
     return {"success": True, "sessionId": sessionId}
 
 
+def app_config_res():
+    return {"hostManifest": {"lab": {"workcell": "something.bar.foo"}}}
+
+
 def mock_api_endpoint():
     return "foo.bar.baz/lab/workcell"
+
+
+def mockget(*args, **kwargs):
+    return MockResponse(0, app_config_res(), json.dumps(app_config_res()))
 
 
 @pytest.fixture
@@ -39,12 +47,13 @@ def test_good_autoprotocol(cli_test_runner, monkeypatch, ap_file):
         )
 
     monkeypatch.setattr(requests, "post", mockpost)
+    monkeypatch.setattr(requests, "get", mockget)
     result = cli_test_runner.invoke(
         cli, ["exec", str(ap_file), "-a", mock_api_endpoint()]
     )
     assert result.exit_code == 0
     assert (
-        f"Success. View {mock_api_endpoint()}/dashboard?sessionId=testSessionId to see the scheduling outcome."
+        f"Success. View http://{mock_api_endpoint()}/dashboard to see the scheduling outcome."
         in result.output
     )
 
@@ -81,6 +90,7 @@ def test_bad_api_response(cli_test_runner, monkeypatch, ap_file):
         return MockResponse(0, "not-json", "not-json")
 
     monkeypatch.setattr(requests, "post", mockpost)
+    monkeypatch.setattr(requests, "get", mockget)
     result = cli_test_runner.invoke(
         cli, ["exec", str(ap_file), "-a", mock_api_endpoint()]
     )
@@ -95,12 +105,13 @@ def test_good_workcell(cli_test_runner, monkeypatch, ap_file):
         )
 
     monkeypatch.setattr(requests, "post", mockpost)
+    monkeypatch.setattr(requests, "get", mockget)
     result = cli_test_runner.invoke(
         cli, ["exec", str(ap_file), "-a", mock_api_endpoint(), "-w", "wc3"]
     )
     assert result.exit_code == 0
     assert (
-        f"Success. View {mock_api_endpoint()}/dashboard?sessionId=testSessionId to see the scheduling outcome."
+        f"Success. View http://{mock_api_endpoint()}/dashboard to see the scheduling outcome."
         in result.output
     )
 
@@ -124,6 +135,7 @@ def test_session_id(cli_test_runner, monkeypatch, ap_file):
         )
 
     monkeypatch.setattr(requests, "post", mockpost)
+    monkeypatch.setattr(requests, "get", mockget)
     result = cli_test_runner.invoke(
         cli,
         [
@@ -137,7 +149,7 @@ def test_session_id(cli_test_runner, monkeypatch, ap_file):
     )
     assert result.exit_code == 0
     assert (
-        f"Success. View {mock_api_endpoint()}/dashboard?sessionId={sessionId} to see the scheduling outcome."
+        f"Success. View http://{mock_api_endpoint()}/dashboard to see the scheduling outcome."
         in result.output
     )
 

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -641,7 +641,7 @@ def format_cmd(manifest):
 @click.option(
     "--workcell-id",
     "-w",
-    help="The workcell id to use for the device set (wc4, tst-01, etc.). This is not permitted along with the `device-set` or `session-id` option.",
+    help="The workcell id to use for the device set (wc4-mcx1, tst-01-mcx-01, etc.). This is not permitted along with the `device-set` or `session-id` option.",
 )
 @click.option(
     "--device-set",

--- a/transcriptic/cli.py
+++ b/transcriptic/cli.py
@@ -641,7 +641,7 @@ def format_cmd(manifest):
 @click.option(
     "--workcell-id",
     "-w",
-    help="The workcell id to use for the device set. This is not permitted along with the `device-set` or `session-id` option.",
+    help="The workcell id to use for the device set (wc4, tst-01, etc.). This is not permitted along with the `device-set` or `session-id` option.",
 )
 @click.option(
     "--device-set",

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1575,7 +1575,11 @@ def execute(
     res = requests.get(f"{path_base}/app-config")
     try:
         res_json = json.loads(res.text)
-        if res_json["hostManifest"] and res_json["hostManifest"][path_lab] and res_json["hostManifest"][path_lab][path_workcell]:
+        if (
+            res_json["hostManifest"]
+            and res_json["hostManifest"][path_lab]
+            and res_json["hostManifest"][path_lab][path_workcell]
+        ):
             frontend_node_address = res_json["hostManifest"][path_lab][path_workcell]
         else:
             click.echo(f"Error when get frontend node address: {res_json}", err=True)
@@ -1583,7 +1587,6 @@ def execute(
     except json.decoder.JSONDecodeError:
         click.echo(f"Error when get frontend node address: {res.text}", err=True)
         return
-
 
     # POST to workcell
     test_run_endpoint = f"http://{frontend_node_address}/testRun"

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1546,12 +1546,8 @@ def execute(
         in_use.append("--device-set")
 
     if workcell_id:
-        if re.search("^wc[a-z,0-9]+$", workcell_id):
-            workcell_id = f"{workcell_id}-mcx1"
-        elif workcell_id == "tst-01":
-            workcell_id = f"{workcell_id}-mcx-01"
-        else:
-            raise BadParameter(f"Workcell id must be like wcN or tst-01 but was {workcell_id}")
+        if "." in workcell_id:
+            raise BadParameter(f"Workcell id can't have '.' but was {workcell_id}")
         payload["workcellIdForDeviceSet"] = workcell_id
         in_use.append("--workcell-id")
 

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1490,18 +1490,21 @@ def execute(
     partitioning_swap_device_id,
 ):
     # Clean api end point
-    if api[-1] == "/":
-        clean_api = api[0:-1]  # remove trailing slash
+    if api.startswith("http://"):
+        clean_api = api[7:]
     else:
         clean_api = api
+    if clean_api[-1] == "/":
+        clean_api = clean_api[0:-1]  # remove trailing slash
 
     # Validate api
     path_tokens = clean_api.split("/")
     if len(path_tokens) != 3:
-        click.echo(f"", err=True)
+        click.echo(f"Invalid api target: {api}.", err=True)
         return
 
-    path_base = path_tokens[0]
+    clean_api = f"http://{clean_api}"
+    path_base = f"http://{path_tokens[0]}"
     path_lab = path_tokens[1]
     path_workcell = path_tokens[2]
 
@@ -1569,7 +1572,7 @@ def execute(
     if partitioning_swap_device_id is not None:
         payload["partitioningSwapDeviceId"] = partitioning_swap_device_id
 
-    res = requests.get(path_base + "/app-config")
+    res = requests.get(f"{path_base}/app-config")
     try:
         res_json = json.loads(res.text)
         if res_json["hostManifest"] and res_json["hostManifest"][path_lab] and res_json["hostManifest"][path_lab][path_workcell]:
@@ -1577,15 +1580,13 @@ def execute(
         else:
             click.echo(f"Error when get frontend node address: {res_json}", err=True)
             return
-
-
     except json.decoder.JSONDecodeError:
         click.echo(f"Error when get frontend node address: {res.text}", err=True)
         return
 
 
     # POST to workcell
-    test_run_endpoint = f"{frontend_node_address}/testRun"
+    test_run_endpoint = f"http://{frontend_node_address}/testRun"
     click.echo(f"Sending request to {frontend_node_address}")
     res = requests.post(test_run_endpoint, json=payload)
     try:

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1492,6 +1492,9 @@ def execute(
     # Clean api end point
     if api.startswith("http://"):
         clean_api = api[7:]
+    elif api.startswith("https://"):
+        click.echo("HTTPS endpoint is not supported, falling back to HTTP.")
+        clean_api = api[8:]
     else:
         clean_api = api
     if clean_api[-1] == "/":
@@ -1500,7 +1503,9 @@ def execute(
     # Validate api
     path_tokens = clean_api.split("/")
     if len(path_tokens) != 3:
-        click.echo(f"Invalid api target: {api}.", err=True)
+        click.echo(
+            f"Invalid api target, expects http://base/facility/workcell.", err=True
+        )
         return
 
     clean_api = f"http://{clean_api}"

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1546,9 +1546,13 @@ def execute(
         in_use.append("--device-set")
 
     if workcell_id:
-        if not re.search("^wc[a-z,0-9]+$", workcell_id):
-            raise BadParameter(f"Workcell id must be like wcN but was {workcell_id}")
-        payload["workcellIdForDeviceSet"] = f"{workcell_id}-mcx1"
+        if re.search("^wc[a-z,0-9]+$", workcell_id):
+            workcell_id = f"{workcell_id}-mcx1"
+        elif workcell_id == "tst-01":
+            workcell_id = f"{workcell_id}-mcx-01"
+        else:
+            raise BadParameter(f"Workcell id must be like wcN or tst-01 but was {workcell_id}")
+        payload["workcellIdForDeviceSet"] = workcell_id
         in_use.append("--workcell-id")
 
     if session_id is not None:

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1489,6 +1489,22 @@ def execute(
     partition_horizon,
     partitioning_swap_device_id,
 ):
+    # Clean api end point
+    if api[-1] == "/":
+        clean_api = api[0:-1]  # remove trailing slash
+    else:
+        clean_api = api
+
+    # Validate api
+    path_tokens = clean_api.split("/")
+    if len(path_tokens) != 3:
+        click.echo(f"", err=True)
+        return
+
+    path_base = path_tokens[0]
+    path_lab = path_tokens[1]
+    path_workcell = path_tokens[2]
+
     # Define the initial payload
     payload = {"timeLimit": f"{time_limit}:second"}
 
@@ -1553,27 +1569,36 @@ def execute(
     if partitioning_swap_device_id is not None:
         payload["partitioningSwapDeviceId"] = partitioning_swap_device_id
 
-    # Clean api end point
-    if api[-1] == "/":
-        clean_api = api[0:-1]  # remove trailing slash
-    else:
-        clean_api = api
+    res = requests.get(path_base + "/app-config")
+    try:
+        res_json = json.loads(res.text)
+        if res_json["hostManifest"] and res_json["hostManifest"][path_lab] and res_json["hostManifest"][path_lab][path_workcell]:
+            frontend_node_address = res_json["hostManifest"][path_lab][path_workcell]
+        else:
+            click.echo(f"Error when get frontend node address: {res_json}", err=True)
+            return
+
+
+    except json.decoder.JSONDecodeError:
+        click.echo(f"Error when get frontend node address: {res.text}", err=True)
+        return
+
 
     # POST to workcell
-    test_run_endpoint = f"{clean_api}/testRun"
-    click.echo("Sending request...")
+    test_run_endpoint = f"{frontend_node_address}/testRun"
+    click.echo(f"Sending request to {frontend_node_address}")
     res = requests.post(test_run_endpoint, json=payload)
     try:
         res_json = json.loads(res.text)
         if res_json["success"]:
             click.echo(
-                f"Success. View {clean_api}/dashboard?sessionId={res_json['sessionId']} to see the scheduling outcome."
+                f"Success. View {clean_api}/dashboard to see the scheduling outcome."
             )
         else:
             click.echo(f"Error: {res_json['message']}", err=True)
             if "sessionId" in res_json:
                 click.echo(
-                    f"Dashboard can be seen at: {clean_api}/dashboard?sessionId={res_json['sessionId']}",
+                    f"Dashboard can be seen at: {clean_api}/dashboard",
                     err=True,
                 )
     except json.decoder.JSONDecodeError:


### PR DESCRIPTION
Summary:
The frontend url (lab.core.strateos.com/haven/wctest) is not the same that the url to the frontend node. This would be confusing to user to have to use different one.

The exec method will request the frontend server for the IP of the frontend node, and then make the request to it.

```
$ transcriptic preview Read | transcriptic exec --api http://lab.core.strateos.com/haven/wctest
Sending request to 13.52.223.111:9000
Success. View http://lab.core.strateos.com/haven/wctest/dashboard to see the scheduling outcome.
```