### PR TITLE
fix: upload-release command api.post_release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Changelog
 Unreleased
 ----------
 
+Fixed
+-----
+- upload-release command to release archive requires the `user_id` of the session.
+- Linting, equivalence, and docstring issues.
+
+Updated
+-------
+- Updated pillow version <=8,<9
+
+
 Added
 ~~~~~
 - Python 3.9 support

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ analysis_deps = [
     # Version 1.21 upwards only support Python >= 3.7
     "numpy>=1.14,<=1.20.3",
     "pandas>=1,<2",
-    "pillow>=9",
+    "pillow>=8,<9",
     "plotly>=1.13,<2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ analysis_deps = [
     # Version 1.21 upwards only support Python >= 3.7
     "numpy>=1.14,<=1.20.3",
     "pandas>=1,<2",
-    "pillow>=3,<4",
+    "pillow>=9",
     "plotly>=1.13,<2",
 ]
 

--- a/transcriptic/analysis/spectrophotometry.py
+++ b/transcriptic/analysis/spectrophotometry.py
@@ -140,7 +140,7 @@ class _PlateRead(object):
             is rendered
         plot_type : {"box", "bar", "line", "hist"}, optional
             Type of plot to render
-        \**plot_kwargs : dict, optional
+        plot_kwargs : dict, optional
             Optional dictionary of specifications for your plot type of choice
         """
         py.offline.init_notebook_mode()
@@ -215,7 +215,7 @@ class Absorbance(_PlateRead):
         use_adj: Boolean, optional
             Boolean option which determines if the adjusted absorbance readings
             are used
-        \**plot_kwargs : dict
+        kwargs : dict
             Optional dictionary of specifications for your plot type of choice
         """
         if "title" not in kwargs:

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -159,7 +159,7 @@ def upload_release(api, archive, package):
         bar.update(20)
         try:
             up = api.post_release(
-                data=json.dumps({"release": {"upload_id": upload_id}}),
+                data=json.dumps({"release": {"upload_id": upload_id, "user_id": api.user_id}}),
                 package_id=package_id,
             )
             re = up["id"]

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -159,7 +159,9 @@ def upload_release(api, archive, package):
         bar.update(20)
         try:
             up = api.post_release(
-                data=json.dumps({"release": {"upload_id": upload_id, "user_id": api.user_id}}),
+                data=json.dumps(
+                    {"release": {"upload_id": upload_id, "user_id": api.user_id}}
+                ),
                 package_id=package_id,
             )
             re = up["id"]

--- a/transcriptic/english.py
+++ b/transcriptic/english.py
@@ -114,8 +114,8 @@ class AutoprotocolParser(object):
         def depth_one(steps):
             depth_one = []
             for step in steps:
-                if type(step) is list:
-                    if type(step[0]) is list:
+                if isinstance(step, list):
+                    if isinstance(step[0], list):
                         depth_one.append(step[0])
                     else:
                         depth_one.append(step)
@@ -390,7 +390,7 @@ class AutoprotocolParser(object):
         def print_tree(lst, level=0):
             print("    " * (level - 1) + "+---" * (level > 0) + str(lst[0]))
             for l in lst[1:]:
-                if type(l) is list:
+                if isinstance(l, list):
                     print_tree(l, level + 1)
                 else:
                     print("    " * level + "+---" + l)
@@ -436,12 +436,12 @@ class AutoprotocolParser(object):
                     % (
                         len(g["to"]),
                         len(g["from"]),
-                        ("well" if len(g["from"]) is 1 else "wells"),
+                        ("well" if len(g["from"]) == 1 else "wells"),
                         self.well_list(g["from"]),
                         self.well_list(g["to"]),
                         (
                             f"data saved at '{opts['dataref']}'"
-                            if i is 0
+                            if i == 0
                             else "analyzed with previous"
                         ),
                     )

--- a/transcriptic/util.py
+++ b/transcriptic/util.py
@@ -43,7 +43,7 @@ def regex_manifest(protocol, input):
     """Special input types, gets updated as more input types are added"""
     if "type" in input and input["type"] == "choice":
         if "options" in input:
-            pattern = "\[(.*?)\]"
+            pattern = r"\[(.*?)\]"
             match = re.search(pattern, str(input["options"]))
             if not match:
                 click.echo(


### PR DESCRIPTION
To upload the release archive to an org the POST data requires the `user_id` of the session.