### PR TITLE
STDV-1553: Update Tx Connection API for permutations of setting auth

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-v9.6.1
+Unreleased
 ------
 
 Updated

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v9.6.1
+------
+
+Updated
+-------
+- Preferring Bearer token over user token when configuring Connection session
+
 v9.6.0
 ------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 Unreleased
-------
+----------
 
 Updated
 -------

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -430,7 +430,9 @@ class ConnectionInitTests(unittest.TestCase):
 
         get_request = requests.Request("GET", "http://foo:5555/get")
         prepared_get = connection.session.prepare_request(get_request)
+
         self.assertTrue("authorization" in prepared_get.headers)
+        self.assertTrue("x-user-token" not in prepared_get.headers)
         self.assertTrue(
             connection.session.auth.token == prepared_get.headers["authorization"]
         )

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -431,7 +431,9 @@ class ConnectionInitTests(unittest.TestCase):
         get_request = requests.Request("GET", "http://foo:5555/get")
         prepared_get = connection.session.prepare_request(get_request)
         self.assertTrue("authorization" in prepared_get.headers)
-        self.assertTrue(connection.session.auth.token == prepared_get.headers['authorization'])
+        self.assertTrue(
+            connection.session.auth.token == prepared_get.headers["authorization"]
+        )
         self.assertTrue(
             prepared_get.headers["X-Organization-Id"] == connection.organization_id
         )

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -388,18 +388,33 @@ class ConnectionInitTests(unittest.TestCase):
                 user_id="ufoo2",
             )
 
-    def test_user_token_supersedes_bearer_token(self):
+    def test_bearer_token_supersedes_user_token(self):
         """Verify that the user token and bearer token are mutually exclusive and that
-        user token supersedes bearer token"""
+        bearer token supersedes user token"""
 
         user_token = "userTokenFoo"
+        bearer_token = (
+            "Bearer eyJraWQiOiJWcmVsOE9zZ0JXaUpHeEpMeFJ4bE1UaVwvbjgyc1hwWktUaTd2UExUNFQ0T"
+            "T0iLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2IiwidG9r"
+            "ZW5fdXNlIjoiYWNjZXNzIiwic2NvcGUiOiJ3ZWJcL2dldCB3ZWJcL3Bvc3QiLCJhdXRoX3RpbWUi"
+            "OjE1OTM3MjM1NDgsImlzcyI6Imh0dHBzOlwvXC9jb2duaXRvLWlkcC51cy1lYXN0LTEuYW1hem9u"
+            "YXdzLmNvbVwvdXMtZWFzdC0xX1d6aEZzTGlPRyIsImV4cCI6MTU5MzcyNzE0OCwiaWF0IjoxNTkz"
+            "NzIzNTQ4LCJ2ZXJzaW9uIjoyLCJqdGkiOiI4Njk5ZDEwYy05Mjg4LTQ0YmEtODIxNi01OTJjZGU3"
+            "MDBhY2MiLCJjbGllbnRfaWQiOiJoMTBlM2hwajliNjc4bXMwOG8zbGlibHQ2In0.YA_yiD-x6UuB"
+            "MShprUbUKuB_DO6ogCtd5srfgpJA6Ve_qsf8n19nVMmFsZBy3GxzN92P1ZXiFY99FfNPohhQtaRR"
+            "hpeUkir08hgJN2bEHCJ5Ym8r9mr9mlwSG6FoiedgLaUVGwJujD9c2rcA83NEo8ayTyfCynF2AZ2p"
+            "MxLHvqOYtvscGMiMzIwlZfJV301iKUVgPODJM5lpJ4iKCpOy2ByCl2_KL1uxIxgMkglpB-i7kgJc"
+            "-WmYoJFoN88D89ugnEoAxNfK14N4_RyEkrLNGape9kew79nUeR6fWbVFLiGDDu25_9z-7VB-GGGk"
+            "7L_Hb7YgVJ5W2FwESnkDvV1T4Q"
+        )
+
         with tempfile.NamedTemporaryFile() as config_file:
             with open(config_file.name, "w") as f:
                 json.dump(
                     {
                         "email": "somebody@transcriptic.com",
                         "token": user_token,
-                        "bearer_token": "bearerTokenBar",
+                        "bearer_token": bearer_token,
                         "organization_id": "transcriptic",
                         "api_root": "http://foo:5555",
                         "analytics": True,
@@ -415,7 +430,8 @@ class ConnectionInitTests(unittest.TestCase):
 
         get_request = requests.Request("GET", "http://foo:5555/get")
         prepared_get = connection.session.prepare_request(get_request)
-        self.assertFalse("authorization" in prepared_get.headers)
+        self.assertTrue("authorization" in prepared_get.headers)
+        self.assertTrue(connection.session.auth.token == prepared_get.headers['authorization'])
         self.assertTrue(
             prepared_get.headers["X-Organization-Id"] == connection.organization_id
         )

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -156,15 +156,15 @@ class Connection(object):
                 )
             self.session.headers["Cookie"] = None
             self.email = email
-            if token is not None:
-                self.token = token
-                if bearer_token is not None:
+            if bearer_token is not None:
+                if token is not None:
                     warnings.warn(
                         "User token and bearer token authentication"
-                        "is mutually exclusive. Ignoring bearer token"
+                        "is mutually exclusive. Ignoring user token"
                     )
-            elif bearer_token is not None:
                 self.bearer_token = bearer_token
+            elif token is not None:
+                self.token = token
             self.update_session_auth()
 
         # Initialize feature groups


### PR DESCRIPTION
In this PR we change the preference from using the user token to preferring to user the bearer token. These changes also have to be used when we configure a Connection session in our current post-run programs -> https://github.com/strateos/internal_protocols/pull/759 , most post-run programs use the `internal_protocols/config/api.py` to configure their session connection.

https://strateos.atlassian.net/browse/STDV-1553
