### PR TITLE
PP-9388: replace by kit_items json field

### DIFF
--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -571,7 +571,7 @@ def resources(api, query):
                         if "vendor" in list(x.keys())
                         else "",
                     }
-                    for y in x["kit_items"]
+                    for y in x["orderable_material_components"]
                     if (y["provisionable"] and not y["reservable"])
                 ],
                 kit_req["results"],


### PR DESCRIPTION
[PP-9388](https://strateos.atlassian.net/browse/PP-9388)
We are introducing a breaking change with the `material refactor` !!
The `kit_items` field is replaced by `orderable_material_components`
