### PR TITLE
Stdv-1817: Update Tx CLI to use "strateos" as default API root

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,5 @@
 Changelog
 =========
-Unreleased
-----------
 
 Updated
 ~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ v9.7.0
 ------
 
 Updated
-~~~~~
+~~~~~~~
 - Transcriptic CLI to use "strateos" not "transcriptic" as default API root
 
 Unreleased

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-Updated
-~~~~~~~
-- Transcriptic CLI to use "strateos" not "transcriptic" as default API root
-
 Unreleased
 ----------
+
+Updated
+---------
+- Transcriptic CLI to use "strateos" not "transcriptic" as default API root
+
 
 Updated
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+v9.7.0
+------
+
+Updated
+~~~~~
+- Transcriptic CLI to use "strateos" not "transcriptic" as default API root
 
 Unreleased
 ----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
-v9.7.0
-------
+Unreleased
+----------
 
 Updated
 ~~~~~~~

--- a/transcriptic/commands.py
+++ b/transcriptic/commands.py
@@ -1074,7 +1074,7 @@ def login(api, config, api_root=None, analytics=True, rsa_key=None):
         try:
             api_root = api.api_root
         except ValueError:
-            api_root = "https://secure.transcriptic.com"
+            api_root = "https://secure.strateos.com"
 
     rsa_auth = None
     rsa_key_path = None


### PR DESCRIPTION
Update Transcriptic CLI to use "strateos" not "transcriptic" as default API root https://strateos.atlassian.net/browse/STDV-1817