### PR TITLE
fix: Rebuild auth even on redirects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Changelog
 
 Unreleased
 ----------
+Fixed
+-----
+- Always rebuild authorization headers even on redirects
 
 Updated
 -------

--- a/transcriptic/auth.py
+++ b/transcriptic/auth.py
@@ -7,7 +7,23 @@ from urllib.parse import urlparse
 from Crypto.Hash import SHA256
 from httpsig.requests_auth import HTTPSignatureAuth
 from httpsig.utils import HttpSigException
+from requests import Session
 from requests.auth import AuthBase
+
+
+class AuthSession(Session):
+    """Custom Session to handle any auth specific behaviors"""
+
+    def rebuild_auth(self, prepared_request, response):
+        """
+        Monkey-patches original rebuild_auth method which handles auth building
+        for redirects. In cases where we're using any of our StrateosAuthBase
+        classes, we want to always apply our own internal auth logic handlers.
+        """
+        if isinstance(self.auth, StrateosAuthBase):
+            prepared_request.prepare_auth(self.auth)
+        else:
+            super().rebuild_auth(prepared_request, response)
 
 
 class StrateosAuthBase(AuthBase, ABC):

--- a/transcriptic/config.py
+++ b/transcriptic/config.py
@@ -1,6 +1,8 @@
+import http.client as http_client
 import inspect
 import io
 import json
+import logging
 import os
 import platform
 import time
@@ -13,7 +15,7 @@ import transcriptic
 from Crypto.PublicKey import RSA
 
 from . import routes
-from .auth import StrateosBearerAuth, StrateosSign
+from .auth import AuthSession, StrateosBearerAuth, StrateosSign
 from .util import is_valid_jwt_token
 from .version import __version__
 
@@ -34,7 +36,7 @@ def initialize_default_session():
     Initialize a default `requests.Session()` object which can be used for
     requests into the tx web api.
     """
-    session = requests.Session()
+    session = AuthSession()
     session.headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",


### PR DESCRIPTION
## Summary

In the case where redirects are hit, we are currently following the default requests session rebuild_auth behavior which does not re-call any of our internal auth handlers.

This results in a case where a redirected request has a stale signature resulting in an auth error.