### PR TITLE
build: Pin to Ubuntu 20.04 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,8 @@ on:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-latest
+    # Pin to 20.04 as we still require Python 3.6
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
@@ -49,7 +50,8 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: ubuntu-latest
+    # Pin to 20.04 as we still require Python 3.6
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout
@@ -70,7 +72,8 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    # Pin to 20.04 as we still require Python 3.6
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Checkout
@@ -91,7 +94,8 @@ jobs:
 
   build-and-publish:
     name: Build and Publish
-    runs-on: ubuntu-latest
+    # Pin to 20.04 as we still require Python 3.6
+    runs-on: ubuntu-20.04
     needs: [tests, docs, lint]
     if: startsWith(github.ref, 'refs/tags')
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 Unreleased
 ----------
 
+Updated
+-------
+- Pin CI environment to Ubuntu 20.04 to support running Py 36 tests
+
 v9.6.1
 ------
 


### PR DESCRIPTION
## Summary

We're seeing test failures in the CI due to being unable to resolve Python 3.6. This is due to using ubuntu-latest, which has dropped support for Python 3.6. 

Pin to the previous version of Ubuntu supporting 3.6, which is 20.04